### PR TITLE
Don't expand shell variable in the custom_user_script

### DIFF
--- a/data/user_data.sh.erb
+++ b/data/user_data.sh.erb
@@ -39,7 +39,7 @@ chroot $imagedir apt-get update
 chroot $imagedir apt-get dist-upgrade -y
 
 # RUN CUSTOM USER SCRIPT
-cat <<CUSTOM_SCRIPT_EOF > $imagedir/tmp/custom_user_script
+cat <<'CUSTOM_SCRIPT_EOF' > $imagedir/tmp/custom_user_script
 <%= custom_user_script %>
 CUSTOM_SCRIPT_EOF
 


### PR DESCRIPTION
The provided custom script is copied into the body of the user_data.sh
script run by the build_ubuntu_ami before being written out to
disk. This causes any shell variables to be expanded in the parent
script.

For example, consider the following custom script:

```
. /etc/lsb-release
REPO_DEB_URL="http://apt.puppetlabs.com/puppetlabs-release-${DISTRIB_CODENAME}.deb"
#...
repo_deb_path=$(mktemp)
wget --output-document=${repo_deb_path} ${REPO_DEB_URL} 2>/dev/null
dpkg -i ${repo_deb_path} >/dev/null
```

This gets exanded into the following broken code:

```
. /etc/lsb-release
REPO_DEB_URL="http://apt.puppetlabs.com/puppetlabs-release-.deb"
#...
repo_deb_path=/tmp/tmp.lmtBQ780ba
wget --output-document=  "http://apt.puppetlabs.com/puppetlabs-release-.deb" 2>/dev/null
dpkg -i >/dev/null
```

There are two problems here:
1. ${repo_deb_path} ends up empty in the final script.
2. /etc/lsb-release is not sourced in the parent script, so
   ${DISTRIB_CODENAME} is expanded to an empty string.

Quoting the custom script within the body of the user_data.sh script
prevents variable expansion until the custom script is executed,
fixing the problem.
