### PR TITLE
Fixing typo which is preventing resolv.conf from working properly

### DIFF
--- a/data/user_data.sh.erb
+++ b/data/user_data.sh.erb
@@ -54,8 +54,8 @@ chroot $imagedir /tmp/custom_user_script
 # END CUSTOM USER SCRIPT
 
 # Put resolv.conf symlink back in place
-rm -rf  $imagedir/etc/resolve.conf
-if [ -e $imagedir/etc/resolve.conf.bak ]; then mv $imagedir/etc/resolv.conf.bak $imagedir/etc/resolv.conf; fi
+rm -f  $imagedir/etc/resolv.conf
+if [ -L $imagedir/etc/resolv.conf.bak ]; then mv $imagedir/etc/resolv.conf.bak $imagedir/etc/resolv.conf; fi
 
 # Clean up chroot environment
 chroot $imagedir umount /proc


### PR DESCRIPTION
I believe I introduced this bug awhile back. I'm also updating the if statement to use -L vs -e since its testing for a symlink.
